### PR TITLE
Add Async Timeout Iterator

### DIFF
--- a/iterators/__init__.py
+++ b/iterators/__init__.py
@@ -1,3 +1,3 @@
-from .timeout_iterator import TimeoutIterator
+from .timeout_iterator import TimeoutIterator, AsyncTimeoutIterator
 
-__all__ = ["TimeoutIterator"]
+__all__ = ["TimeoutIterator", "AsyncTimeoutIterator"]

--- a/iterators/timeout_iterator.py
+++ b/iterators/timeout_iterator.py
@@ -1,10 +1,11 @@
 import queue
+import asyncio
 import threading
 
 class TimeoutIterator:
     """
     Wrapper class to add timeout feature to synchronous iterators
-    - timeout: initial default timeout
+    - timeout: timeout for next(). Default=ZERO_TIMEOUT i.e. no timeout or blocking calls to next. Updated using set_timeout() 
     - sentinel: the object returned by iterator when timeout happens
     - reset_on_next: if set to True, timeout is reset to the value of ZERO_TIMEOUT on each iteration
 
@@ -90,3 +91,69 @@ class TimeoutIterator:
                     raise StopIteration()
         except BaseException as e:
             self._buffer.put(e)
+
+class AsyncTimeoutIterator:
+    """
+    Async version of TimeoutIterator. See method documentation of TimeoutIterator
+    """
+    ZERO_TIMEOUT = 0.0
+
+    def __init__(self, iterator, timeout=0.0, sentinel=object(), reset_on_next=False):
+        self._iterator = iterator
+        self._timeout = timeout
+        self._sentinel= sentinel
+        self._reset_on_next = reset_on_next
+
+        self._interrupt = False
+        self._done = False
+        self._buffer = asyncio.Queue()
+        self._task = asyncio.get_event_loop().create_task(self.__lookahead())
+
+    def get_sentinel(self):
+        return self._sentinel
+
+    def set_reset_on_next(self, reset_on_next):
+        self._reset_on_next = reset_on_next
+
+    def set_timeout(self, timeout: float):
+        self._timeout = timeout
+
+    def interrupt(self):
+        self._interrupt = True
+
+    def __iter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._done:
+            raise StopAsyncIteration
+
+        data = self._sentinel
+        try:
+            if self._timeout > self.ZERO_TIMEOUT:
+                data = await asyncio.wait_for(self._buffer.get(), self._timeout)
+            else:
+                data = await self._buffer.get()
+        except asyncio.TimeoutError:
+            pass
+        finally:
+            # see if timeout needs to be reset
+            if self._reset_on_next:
+                self._timeout = self.ZERO_TIMEOUT
+
+        # propagate any exceptions including StopIteration
+        if isinstance(data, BaseException):
+            self._done = True
+            raise data
+
+        return data
+
+    async def __lookahead(self):
+        try:
+            while True:
+                data = await self._iterator.__anext__()
+                await self._buffer.put(data)
+                if self._interrupt:
+                    raise StopAsyncIteration()
+        except BaseException as e:
+            await self._buffer.put(e)

--- a/tests/test_async_timeout_iterator.py
+++ b/tests/test_async_timeout_iterator.py
@@ -1,0 +1,168 @@
+import unittest
+import asyncio
+
+from iterators import AsyncTimeoutIterator
+
+
+async def iter_simple():
+    yield 1
+    yield 2
+
+
+async def iter_with_sleep():
+    yield 1
+    await asyncio.sleep(0.6)
+    yield 2
+    await asyncio.sleep(0.4)
+    yield 3
+
+
+async def iter_with_exception():
+    yield 1
+    yield 2
+    raise Exception
+    yield 3
+
+
+class TestTimeoutIterator(unittest.TestCase):
+
+    def test_normal_iteration(self):
+
+        async def _(self):
+
+            i = iter_simple()
+            it = AsyncTimeoutIterator(i)
+
+            self.assertEqual(await it.__anext__(), 1)
+            self.assertEqual(await it.__anext__(), 2)
+
+            with self.assertRaises(StopAsyncIteration):
+                await it.__anext__()
+            with self.assertRaises(StopAsyncIteration):
+                await it.__anext__()
+
+        asyncio.get_event_loop().run_until_complete(_(self))
+
+
+    def test_timeout_block(self):
+
+        async def _(self):
+            i = iter_with_sleep()
+            it = AsyncTimeoutIterator(i)
+            self.assertEqual(await it.__anext__(), 1)
+            self.assertEqual(await it.__anext__(), 2)
+            self.assertEqual(await it.__anext__(), 3)
+
+            with self.assertRaises(StopAsyncIteration):
+                await it.__anext__()
+            with self.assertRaises(StopAsyncIteration):
+                            await it.__anext__()
+
+        asyncio.get_event_loop().run_until_complete(_(self))
+
+    def test_fixed_timeout(self):
+
+        async def _(self):
+            i = iter_with_sleep()
+            it = AsyncTimeoutIterator(i, timeout=0.5)
+
+            self.assertEqual(await it.__anext__(), 1)
+            self.assertEqual(await it.__anext__(), it.get_sentinel())
+            self.assertEqual(await it.__anext__(), 2)
+            self.assertEqual(await it.__anext__(), 3)
+            with self.assertRaises(StopAsyncIteration):
+                await it.__anext__()
+        asyncio.get_event_loop().run_until_complete(_(self))
+
+    def test_timeout_update(self):
+        async def _(self):
+            i = iter_with_sleep()
+            it = AsyncTimeoutIterator(i, timeout=0.5)
+
+            self.assertEqual(await it.__anext__(), 1)
+            self.assertEqual(await it.__anext__(), it.get_sentinel())
+
+            it.set_timeout(0.3)
+            self.assertEqual(await it.__anext__(), 2)
+            self.assertEqual(await it.__anext__(), it.get_sentinel())
+
+            self.assertEqual(await it.__anext__(), 3)
+
+            with self.assertRaises(StopAsyncIteration):
+                await it.__anext__()
+
+        asyncio.get_event_loop().run_until_complete(_(self))
+
+    def test_custom_sentinel(self):
+        async def _(self):
+            i = iter_with_sleep()
+            it = AsyncTimeoutIterator(i, timeout=0.5, sentinel="END")
+            self.assertEqual(await it.__anext__(), 1)
+            self.assertEqual(await it.__anext__(), "END")
+
+            self.assertEqual(await it.__anext__(), 2)
+            self.assertEqual(await it.__anext__(), 3)
+
+            with self.assertRaises(StopAsyncIteration):
+                await it.__anext__()
+
+        asyncio.get_event_loop().run_until_complete(_(self))
+
+    def test_feature_timeout_reset(self):
+        async def _(self):
+            i = iter_with_sleep()
+            it = AsyncTimeoutIterator(i, timeout=0.5, reset_on_next=True)
+
+            self.assertEqual(await it.__anext__(), 1) # timeout gets reset after first iteration
+            self.assertEqual(await it.__anext__(), 2)
+            self.assertEqual(await it.__anext__(), 3)
+
+            with self.assertRaises(StopAsyncIteration):
+                await it.__anext__()
+
+        asyncio.get_event_loop().run_until_complete(_(self))
+
+    def test_function_set_reset_on_next(self):
+        async def _(self):
+            i = iter_with_sleep()
+            it = AsyncTimeoutIterator(i, timeout=0.35, reset_on_next=False)
+
+            self.assertEqual(await it.__anext__(), 1)
+            self.assertEqual(await it.__anext__(), it.get_sentinel())
+            it.set_reset_on_next(True)
+            self.assertEqual(await it.__anext__(), 2)
+            self.assertEqual(await it.__anext__(), 3)
+
+            with self.assertRaises(StopAsyncIteration):
+                await it.__anext__()
+
+        asyncio.get_event_loop().run_until_complete(_(self))
+
+    def test_iterator_raises_exception(self):
+        async def _(self):
+            i = iter_with_exception()
+            it = AsyncTimeoutIterator(i, timeout=0.5, sentinel="END")
+            self.assertEqual(await it.__anext__(), 1)
+            self.assertEqual(await it.__anext__(), 2)
+
+            with self.assertRaises(Exception):
+                await it.__anext__()
+            with self.assertRaises(StopAsyncIteration):
+                await it.__anext__()
+
+        asyncio.get_event_loop().run_until_complete(_(self))
+
+
+    def test_interrupt_thread(self):
+        async def _(self):
+            i = iter_with_sleep()
+            it = AsyncTimeoutIterator(i, timeout=0.5, sentinel="END")
+            self.assertEqual(await it.__anext__(), 1)
+            self.assertEqual(await it.__anext__(), it.get_sentinel())
+            it.interrupt()
+            self.assertEqual(await it.__anext__(), 2)
+
+            with self.assertRaises(StopAsyncIteration):
+                await it.__anext__()
+
+        asyncio.get_event_loop().run_until_complete(_(self))


### PR DESCRIPTION
Add async version:
1. `__anext__` method to support async iteration.
1. Uses `aysncio.Queue` under the hood.