### PR TITLE
Make AsyncTimeoutIterator an async iterator

### DIFF
--- a/iterators/timeout_iterator.py
+++ b/iterators/timeout_iterator.py
@@ -121,7 +121,7 @@ class AsyncTimeoutIterator:
     def interrupt(self):
         self._interrupt = True
 
-    def __iter__(self):
+    def __aiter__(self):
         return self
 
     async def __anext__(self):

--- a/tests/test_async_timeout_iterator.py
+++ b/tests/test_async_timeout_iterator.py
@@ -43,6 +43,18 @@ class TestTimeoutIterator(unittest.TestCase):
 
         asyncio.get_event_loop().run_until_complete(_(self))
 
+    def test_normal_iteration_for_loop(self):
+
+        async def _(self):
+
+            i = iter_simple()
+            it = AsyncTimeoutIterator(i)
+            iterResults = []
+            async for x in it: 
+                iterResults.append(x)        
+            self.assertEqual(iterResults, [1,2])
+
+        asyncio.get_event_loop().run_until_complete(_(self))
 
     def test_timeout_block(self):
 
@@ -60,6 +72,18 @@ class TestTimeoutIterator(unittest.TestCase):
 
         asyncio.get_event_loop().run_until_complete(_(self))
 
+    def test_timeout_block_for_loop(self):
+
+        async def _(self):
+            i = iter_with_sleep()
+            it = AsyncTimeoutIterator(i)
+            iterResults = []
+            async for x in it: 
+                iterResults.append(x)        
+            self.assertEqual(iterResults, [1,2,3])
+
+        asyncio.get_event_loop().run_until_complete(_(self))
+
     def test_fixed_timeout(self):
 
         async def _(self):
@@ -72,6 +96,18 @@ class TestTimeoutIterator(unittest.TestCase):
             self.assertEqual(await it.__anext__(), 3)
             with self.assertRaises(StopAsyncIteration):
                 await it.__anext__()
+        asyncio.get_event_loop().run_until_complete(_(self))
+        
+    def test_fixed_timeout(self):
+
+        async def _(self):
+            i = iter_with_sleep()
+            it = AsyncTimeoutIterator(i, timeout=0.5)
+            iterResults = []
+            async for x in it: 
+                iterResults.append(x)        
+            self.assertEqual(iterResults, [1,it.get_sentinel(),2,3])
+                
         asyncio.get_event_loop().run_until_complete(_(self))
 
     def test_timeout_update(self):

--- a/tests/test_timeout_iterator.py
+++ b/tests/test_timeout_iterator.py
@@ -32,6 +32,15 @@ class TestTimeoutIterator(unittest.TestCase):
         self.assertRaises(StopIteration, next, it)
         self.assertRaises(StopIteration, next, it)
 
+
+    def test_normal_iteration_for_loop(self):
+        i = iter_simple()
+        it = TimeoutIterator(i)
+        iterResults = []
+        for x in it: 
+            iterResults.append(x)        
+        self.assertEqual(iterResults, [1,2])
+
     def test_timeout_block(self):
         i = iter_with_sleep()
         it = TimeoutIterator(i)
@@ -41,6 +50,14 @@ class TestTimeoutIterator(unittest.TestCase):
         self.assertRaises(StopIteration, next, it)
         self.assertRaises(StopIteration, next, it)
 
+    def test_timeout_block_for_loop(self):
+        i = iter_with_sleep()
+        it = TimeoutIterator(i)        
+        iterResults = []
+        for x in it: 
+            iterResults.append(x)            
+        self.assertEqual(iterResults, [1,2,3])
+    
     def test_fixed_timeout(self):
         i = iter_with_sleep()
         it = TimeoutIterator(i, timeout=0.5)
@@ -50,6 +67,14 @@ class TestTimeoutIterator(unittest.TestCase):
         self.assertEqual(next(it), 2)
         self.assertEqual(next(it), 3)
         self.assertRaises(StopIteration, next, it)
+
+    def test_fixed_timeout_for_loop(self):
+        i = iter_with_sleep()
+        it = TimeoutIterator(i, timeout=0.5)        
+        iterResults = []
+        for x in it: 
+            iterResults.append(x)            
+        self.assertEqual(iterResults, [1,it.get_sentinel(),2,3])
 
     def test_timeout_update(self):
         i = iter_with_sleep()


### PR DESCRIPTION
AsyncTimeoutIterator  is not iterable with `__next__` and should not implement `__iter__`. 
Instead it should implement `__aiter__` as it is asynchronously iterable with `__anext__`. 

This allows use as:
```python
async for x in my_async_timeout_iterator
```